### PR TITLE
fix: Translate config keys to local layout before comparison

### DIFF
--- a/Sources/AltAppSwitcher/AppMode.c
+++ b/Sources/AltAppSwitcher/AppMode.c
@@ -1980,7 +1980,7 @@ static int ProcessKeys(struct WindowData* windowData, UINT uMsg, WPARAM wParam, 
             x = -1;
         }
         if (x != 0) {
-            const bool invert = GetAsyncKeyState((SHORT)windowData->StaticData->Config->Key.Invert) & 0x8000;
+            const bool invert = GetAsyncKeyState((SHORT)USKeyToLocalKey(windowData->StaticData->Config->Key.Invert)) & 0x8000;
             MoveSelection(windowData, invert ? -x : x);
             return 0;
         }

--- a/Sources/AltAppSwitcher/WinMode.c
+++ b/Sources/AltAppSwitcher/WinMode.c
@@ -372,15 +372,14 @@ static LRESULT MainWindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam
             || wParam == VK_DOWN) {
             x = 1;
         } else if (
-            wParam == winSwitch
-            || wParam == 'H'
+            wParam == 'H'
             || wParam == 'K'
             || wParam == VK_LEFT
             || wParam == VK_UP) {
             x = -1;
         }
         if (x != 0) {
-            const bool invert = GetAsyncKeyState((SHORT)windowData.StaticData->Config->Key.Invert) & 0x8000;
+            const bool invert = GetAsyncKeyState((SHORT)USKeyToLocalKey(windowData.StaticData->Config->Key.Invert)) & 0x8000;
             windowData.Selection += invert ? -x : x;
             windowData.Selection = Modulo(windowData.Selection, (int)windowData.CurrentWinGroup.WindowCount);
 #ifdef ASYNC

--- a/Sources/AltAppSwitcher/WinMode.c
+++ b/Sources/AltAppSwitcher/WinMode.c
@@ -363,15 +363,16 @@ static LRESULT MainWindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam
         ASSERT(windowData.StaticData);
         ASSERT(windowData.StaticData->Config);
         int x = 0;
+        const unsigned int winSwitch = USKeyToLocalKey(windowData.StaticData->Config->Key.WinSwitch);
         if (
-            wParam == windowData.StaticData->Config->Key.WinSwitch
+            wParam == winSwitch
             || wParam == 'L'
             || wParam == 'J'
             || wParam == VK_RIGHT
             || wParam == VK_DOWN) {
             x = 1;
         } else if (
-            wParam == windowData.StaticData->Config->Key.WinSwitch
+            wParam == winSwitch
             || wParam == 'H'
             || wParam == 'K'
             || wParam == VK_LEFT


### PR DESCRIPTION
## Summary

App-switcher key comparisons used raw config values, which are stored as US-layout virtual key codes, against layout-translated key events. On non-US keyboard layouts the configured key could match the wrong physical key, or never match at all.

This brings all comparisons in line with the rest of the codebase (App.c, AppMode.c), which already translate config keys via `USKeyToLocalKey()`.

## Changes

- **WinSwitch (WinMode):** translate via `USKeyToLocalKey()` before comparison. Previously the raw config value was compared against the already layout-translated `wParam`, so the switch key never matched on non-US layouts.
- **Invert (WinMode + AppMode):** translate before `GetAsyncKeyState()`, which operates on current-layout VK codes. Affects layout-dependent choices like `tilde` and `q`; the default `left shift` was unaffected since modifiers map to the same code across layouts.
- **Dead code removal (WinMode):** dropped a redundant `wParam == winSwitch` branch in the else-if. WinMode has only one switch key, so that condition always matched the first branch.

## Test plan

- [ ] Set a non-US keyboard layout (e.g. Finnish or AZERTY)
- [ ] Verify the configured WinSwitch key cycles windows in window mode
- [ ] Set Invert to `tilde` or `q` and verify it reverses cycle direction
- [ ] Confirm default config (left shift invert) still works on US layout